### PR TITLE
Refactor: 검색 기능 수정

### DIFF
--- a/src/hooks/useSearchData.tsx
+++ b/src/hooks/useSearchData.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react';
+import { searchTodo } from '../api/todo';
+
+interface UseSearchDataProps {
+  setSearchedResponse: React.Dispatch<React.SetStateAction<string[]>>;
+  setIsMoreLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsNoMoreData: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+function useSearchData({
+  setSearchedResponse,
+  setIsMoreLoading,
+  setIsNoMoreData,
+}: UseSearchDataProps) {
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  const handleSearchData = useCallback(
+    async (type: string, debouncedSearchQuery: string) => {
+      if (debouncedSearchQuery.trim() === '') {
+        setSearchedResponse([]);
+        return;
+      }
+      if (type === 'first') {
+        setCurrentPage(1);
+        setSearchedResponse([]);
+      }
+      if (type === 'scroll') setCurrentPage((prevPage: number) => prevPage + 1);
+      const updateCurrentPage = type === 'scroll' ? currentPage + 1 : 1;
+      setIsMoreLoading(true);
+      const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
+      setSearchedResponse((prevData: string[]) => [...prevData, ...data.result]);
+      setIsNoMoreData(data.page * data.limit >= data.total);
+      setIsMoreLoading(false);
+    },
+    [currentPage, setIsMoreLoading, setSearchedResponse, setIsNoMoreData]
+  );
+
+  return handleSearchData;
+}
+
+export default useSearchData;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,5 +1,4 @@
 import { TodoTypes, getTodoList } from '../api/todo';
-
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { createTodo, searchTodo } from '../api/todo';
 import useDebounce from '../hooks/useDebounce';
@@ -36,10 +35,10 @@ const Main = () => {
   const [isNoMoreData, setIsNoMoreData] = useState<boolean>(true);
 
   // currentPage: 현재 페이지
-  const [currentPage, setCurrentPage] = useState<number>(1);
+  // const [currentPage, setCurrentPage] = useState<number>(1);
 
   // total: 전체 데이터 개수
-  const [total, setTotal] = useState<number>(0);
+  // const [total, setTotal] = useState<number>(0);
 
   // observer: IntersectionObserver 객체
   const observer = useRef<IntersectionObserver | null>(null);
@@ -47,28 +46,53 @@ const Main = () => {
   // debouncedSearchQuery: 디바운스 적용된 검색어
   const debouncedSearchQuery = useDebounce(inputText, DEBOUNCED_DELAY);
 
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  const handleSearchData = useCallback(
+    async (type: string, debouncedSearchQuery: string) => {
+      if (!debouncedSearchQuery) {
+        setSearchedResponse([]);
+        return;
+      }
+      if (type === 'first') {
+        setCurrentPage(1);
+        setSearchedResponse([]);
+      }
+      if (type === 'scroll') setCurrentPage((prevPage: number) => prevPage + 1);
+      const updateCurrentPage = type === 'scroll' ? currentPage + 1 : 1;
+      setIsMoreLoading(true);
+      const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
+      setSearchedResponse((prevData: string[]) => [...prevData, ...data.result]);
+      setIsNoMoreData(data.page * data.limit >= data.total);
+      setIsMoreLoading(false);
+    },
+    [currentPage]
+  );
+
   // loadMoreData: 추가 데이터 로드 함수
-  const loadMoreData = useCallback(async () => {
-    setIsMoreLoading(true);
-    const newData = await searchTodo({ q: debouncedSearchQuery, page: currentPage + 1 });
-    setSearchedResponse((prevData: string[]) => [...prevData, ...newData.data.result]);
-    setTotal(newData.data.total);
-    setCurrentPage((prevPage: number) => prevPage + 1);
-    setIsMoreLoading(false);
-  }, [currentPage, debouncedSearchQuery]);
+  // const loadMoreData = useCallback(async () => {
+  //   setIsMoreLoading(true);
+  //   const newData = await searchTodo({ q: debouncedSearchQuery, page: currentPage + 1 });
+  //   setSearchedResponse((prevData: string[]) => [...prevData, ...newData.data.result]);
+  //   setTotal(newData.data.total);
+  //   setCurrentPage((prevPage: number) => prevPage + 1);
+  //   setIsMoreLoading(false);
+  // }, [currentPage, debouncedSearchQuery]);
 
   // lastItemRef: 마지막 항목의 ref 콜백 함수
   const lastItemRef = useCallback(
     (node: HTMLDivElement | null) => {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting) {
-          loadMoreData();
+        if (entries[0].isIntersecting && !isNoMoreData && !isMoreLoading) {
+          // loadMoreData();
+          handleSearchData('scroll', debouncedSearchQuery);
         }
       });
       if (node) observer.current.observe(node);
     },
-    [loadMoreData]
+    // [loadMoreData]
+    [debouncedSearchQuery, handleSearchData, isMoreLoading, isNoMoreData]
   );
 
   // onChangeInput: 입력 값 변경 시 처리 함수
@@ -83,17 +107,17 @@ const Main = () => {
   const handleBlur = () => setIsFocused(false);
 
   // handleChange: 검색어 변경 시 처리 함수
-  const handleChange = useCallback(async () => {
-    if (!debouncedSearchQuery) {
-      setSearchedResponse([]);
-      setTotal(0);
-      return;
-    }
-    const response = await searchTodo({ q: debouncedSearchQuery });
-    setSearchedResponse(response.data.result);
-    setTotal(response.data.total);
-    setCurrentPage(1);
-  }, [debouncedSearchQuery]);
+  // const handleChange = useCallback(async () => {
+  //   if (!debouncedSearchQuery) {
+  //     setSearchedResponse([]);
+  //     setTotal(0);
+  //     return;
+  //   }
+  //   const response = await searchTodo({ q: debouncedSearchQuery });
+  //   setSearchedResponse(response.data.result);
+  //   setTotal(response.data.total);
+  //   setCurrentPage(1);
+  // }, [debouncedSearchQuery]);
 
   // handleSubmit: 폼 제출 시 처리 함수
   const handleSubmit = useCallback(
@@ -116,20 +140,24 @@ const Main = () => {
     [inputText]
   );
 
-  useEffect(() => {
-    // 검색 결과가 전체 데이터 개수와 동일하다면 더 이상 데이터가 없음
-    if (searchedResponse.length === total) {
-      setIsNoMoreData(true);
-    } else {
-      setIsNoMoreData(false);
-    }
-  }, [searchedResponse.length, total]);
+  // useEffect(() => {
+  //   // 검색 결과가 전체 데이터 개수와 동일하다면 더 이상 데이터가 없음
+  //   if (searchedResponse.length === total) {
+  //     setIsNoMoreData(true);
+  //   } else {
+  //     setIsNoMoreData(false);
+  //   }
+  // }, [searchedResponse.length, total]);
+
+  // useEffect(() => {
+  //   // 입력 중인지 여부 설정
+  //   setIsTyping(!!debouncedSearchQuery);
+  //   handleChange();
+  // }, [handleChange, debouncedSearchQuery]);
 
   useEffect(() => {
-    // 입력 중인지 여부 설정
-    setIsTyping(!!debouncedSearchQuery);
-    handleChange();
-  }, [handleChange, debouncedSearchQuery]);
+    handleSearchData('first', debouncedSearchQuery);
+  }, [debouncedSearchQuery]);
 
   useEffect(() => {
     // 할 일 목록 데이터 로드

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,6 +1,6 @@
 import { TodoTypes, getTodoList } from '../api/todo';
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { createTodo, searchTodo } from '../api/todo';
+import { createTodo } from '../api/todo';
 import useDebounce from '../hooks/useDebounce';
 import styled from 'styled-components';
 import { DEBOUNCED_DELAY } from '../constants/constant';
@@ -8,6 +8,7 @@ import Header from '../components/Header';
 import InputTodo from '../components/InputTodo';
 import SearchedList from '../components/SearchedList';
 import TodoList from '../components/TodoList';
+import useSearchData from '../hooks/useSearchData';
 
 const Main = () => {
   // todoListData: 할 일 목록 데이터
@@ -46,28 +47,11 @@ const Main = () => {
   // debouncedSearchQuery: 디바운스 적용된 검색어
   const debouncedSearchQuery = useDebounce(inputText, DEBOUNCED_DELAY);
 
-  const [currentPage, setCurrentPage] = useState<number>(1);
-
-  const handleSearchData = useCallback(
-    async (type: string, debouncedSearchQuery: string) => {
-      if (!debouncedSearchQuery) {
-        setSearchedResponse([]);
-        return;
-      }
-      if (type === 'first') {
-        setCurrentPage(1);
-        setSearchedResponse([]);
-      }
-      if (type === 'scroll') setCurrentPage((prevPage: number) => prevPage + 1);
-      const updateCurrentPage = type === 'scroll' ? currentPage + 1 : 1;
-      setIsMoreLoading(true);
-      const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
-      setSearchedResponse((prevData: string[]) => [...prevData, ...data.result]);
-      setIsNoMoreData(data.page * data.limit >= data.total);
-      setIsMoreLoading(false);
-    },
-    [currentPage]
-  );
+  const handleSearchData = useSearchData({
+    setSearchedResponse,
+    setIsMoreLoading,
+    setIsNoMoreData,
+  });
 
   // loadMoreData: 추가 데이터 로드 함수
   // const loadMoreData = useCallback(async () => {
@@ -156,6 +140,8 @@ const Main = () => {
   // }, [handleChange, debouncedSearchQuery]);
 
   useEffect(() => {
+    // 입력 중인지 여부 설정
+    setIsTyping(!!debouncedSearchQuery);
     handleSearchData('first', debouncedSearchQuery);
   }, [debouncedSearchQuery]);
 

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -52,15 +52,13 @@ const Main = () => {
     (node: HTMLDivElement | null) => {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting && !isNoMoreData && !isMoreLoading) {
-          // loadMoreData();
+        if (entries[0].isIntersecting) {
           handleSearchData('scroll', debouncedSearchQuery);
         }
       });
       if (node) observer.current.observe(node);
     },
-    // [loadMoreData]
-    [debouncedSearchQuery, handleSearchData, isMoreLoading, isNoMoreData]
+    [debouncedSearchQuery, handleSearchData]
   );
 
   // onChangeInput: 입력 값 변경 시 처리 함수

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -35,12 +35,6 @@ const Main = () => {
   // isNoMoreData: 더 이상 데이터가 없는지 여부
   const [isNoMoreData, setIsNoMoreData] = useState<boolean>(true);
 
-  // currentPage: 현재 페이지
-  // const [currentPage, setCurrentPage] = useState<number>(1);
-
-  // total: 전체 데이터 개수
-  // const [total, setTotal] = useState<number>(0);
-
   // observer: IntersectionObserver 객체
   const observer = useRef<IntersectionObserver | null>(null);
 
@@ -52,16 +46,6 @@ const Main = () => {
     setIsMoreLoading,
     setIsNoMoreData,
   });
-
-  // loadMoreData: 추가 데이터 로드 함수
-  // const loadMoreData = useCallback(async () => {
-  //   setIsMoreLoading(true);
-  //   const newData = await searchTodo({ q: debouncedSearchQuery, page: currentPage + 1 });
-  //   setSearchedResponse((prevData: string[]) => [...prevData, ...newData.data.result]);
-  //   setTotal(newData.data.total);
-  //   setCurrentPage((prevPage: number) => prevPage + 1);
-  //   setIsMoreLoading(false);
-  // }, [currentPage, debouncedSearchQuery]);
 
   // lastItemRef: 마지막 항목의 ref 콜백 함수
   const lastItemRef = useCallback(
@@ -90,19 +74,6 @@ const Main = () => {
   // handleBlur: 입력창에서 포커스가 벗어날 때 처리 함수
   const handleBlur = () => setIsFocused(false);
 
-  // handleChange: 검색어 변경 시 처리 함수
-  // const handleChange = useCallback(async () => {
-  //   if (!debouncedSearchQuery) {
-  //     setSearchedResponse([]);
-  //     setTotal(0);
-  //     return;
-  //   }
-  //   const response = await searchTodo({ q: debouncedSearchQuery });
-  //   setSearchedResponse(response.data.result);
-  //   setTotal(response.data.total);
-  //   setCurrentPage(1);
-  // }, [debouncedSearchQuery]);
-
   // handleSubmit: 폼 제출 시 처리 함수
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -123,21 +94,6 @@ const Main = () => {
     },
     [inputText]
   );
-
-  // useEffect(() => {
-  //   // 검색 결과가 전체 데이터 개수와 동일하다면 더 이상 데이터가 없음
-  //   if (searchedResponse.length === total) {
-  //     setIsNoMoreData(true);
-  //   } else {
-  //     setIsNoMoreData(false);
-  //   }
-  // }, [searchedResponse.length, total]);
-
-  // useEffect(() => {
-  //   // 입력 중인지 여부 설정
-  //   setIsTyping(!!debouncedSearchQuery);
-  //   handleChange();
-  // }, [handleChange, debouncedSearchQuery]);
 
   useEffect(() => {
     // 입력 중인지 여부 설정


### PR DESCRIPTION
## 개요 :mag:
처음 검색하는 함수와 무한 스크롤로 검색하는 함수에 중복되는 기능이 많아 리팩토링을 진행했습니다.

## 작업사항 :memo:

close #17 Search 커스텀 훅 구현

- `useSearchData` 커스텀 훅 구현 (**currentPage state**는 커스텀 훅으로 분리했습니다.)
- `total -> isNoMoreData`로 전체 검색 결과를 파악하는 로직을 `isNoMoreData` 하나로 처리하도록 수정
- `Main.tsx`에서 사용하지 않는  **total state** 삭제

## 테스트 방법(optional)

1. input에 검색을 진행할 때 검색 결과가 제대로 나오는지 테스트해주세요.
2. 해당 검색 결과가 스크롤 검색이 제대로 되는지 테스트해주세요.
 2-1. 마지막 스크롤까지 검색이 되고 난 후 추가적으로 검색이 실행되지 않는지 테스트해주세요.
3. 검색 결과를 수정하는 경우 바뀐 검색 결과가 제대로 나오는지 테스트해주세요.
4. 다시 해당 검색 결과가 스크롤 검색이 제대로 되는지 테스트해주세요.
 4-1. 마지막 스크롤까지 검색이 되고 난 후 추가적으로 검색이 실행되지 않는지 테스트해주세요.