### PR TITLE
Refactor: context 생성 및 불필요한 props 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
 import './App.css';
+import TodoContextProvider from './contexts/TodoContext';
 import Main from './pages/Main';
 
 const App = () => {
-  return <Main />;
+  return (
+    <TodoContextProvider>
+      <Main />
+    </TodoContextProvider>
+  );
 };
 
 export default App;

--- a/src/components/SearchedItem.tsx
+++ b/src/components/SearchedItem.tsx
@@ -1,17 +1,19 @@
 import { useState } from 'react';
 import styled from 'styled-components';
+import { useTodoDispatch, useTodoState } from '../contexts/TodoContext';
 
 interface SearchedItemProps {
   item: string;
-  inputText: string;
-  setInputText: React.Dispatch<React.SetStateAction<string>>;
 }
 
 interface ListItemProps {
   isSelected: boolean;
 }
 
-const SearchedItem = ({ item, inputText, setInputText }: SearchedItemProps) => {
+const SearchedItem = ({ item }: SearchedItemProps) => {
+  const { inputText } = useTodoState();
+  const { setInputText } = useTodoDispatch();
+
   // isSelected : 아이템이 선택되었는지 여부.
   const [isSelected, setIsSelected] = useState<boolean>(false);
 

--- a/src/components/SearchedList.tsx
+++ b/src/components/SearchedList.tsx
@@ -4,8 +4,6 @@ import { FaSpinner } from 'react-icons/fa';
 
 interface SearchedListProps {
   searchedResponse: string[];
-  inputText: string;
-  setInputText: React.Dispatch<React.SetStateAction<string>>;
   isNoMoreData: boolean;
   lastItemRef: (node: HTMLDivElement | null) => void;
   isMoreLoading: boolean;
@@ -13,8 +11,6 @@ interface SearchedListProps {
 
 const SearchedList = ({
   searchedResponse,
-  inputText,
-  setInputText,
   isNoMoreData,
   lastItemRef,
   isMoreLoading,
@@ -23,7 +19,7 @@ const SearchedList = ({
     <ListContainer>
       <ul>
         {searchedResponse.map((item, index) => (
-          <SearchedItem key={index} item={item} inputText={inputText} setInputText={setInputText} />
+          <SearchedItem key={index} item={item} />
         ))}
       </ul>
       {isMoreLoading ? (

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -2,24 +2,25 @@ import { useCallback, useState, useEffect } from 'react';
 import { TodoTypes, deleteTodo } from '../api/todo';
 import TrashIcon from './Icon/TrashIcon';
 import styled from 'styled-components';
+import { useTodoDispatch } from '../contexts/TodoContext';
 
 interface TodoItemTypes {
   id: string;
   title: string;
-  setTodos: React.Dispatch<React.SetStateAction<TodoTypes[]>>;
 }
 
-const TodoItem = ({ id, title, setTodos }: TodoItemTypes) => {
+const TodoItem = ({ id, title }: TodoItemTypes) => {
   // isDeleting: 할 일 삭제 중 여부
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const { setTodoListData } = useTodoDispatch();
 
   // handleRemoveTodo: 할 일 삭제 처리 함수
   const handleRemoveTodo = useCallback(async () => {
     setIsDeleting(true);
     await deleteTodo(id);
-    setTodos(prev => prev.filter((item: TodoTypes) => item.id !== id));
+    setTodoListData(prev => prev.filter((item: TodoTypes) => item.id !== id));
     setIsDeleting(false);
-  }, [id, setTodos]);
+  }, [id]);
 
   useEffect(() => {
     // 컴포넌트 언마운트 시 isDeleting 상태 초기화

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -4,14 +4,13 @@ import { TodoTypes } from '../api/todo';
 
 interface TodoListTypes {
   todos: TodoTypes[];
-  setTodos: React.Dispatch<React.SetStateAction<TodoTypes[]>>;
 }
 
-const TodoList = ({ todos, setTodos }: TodoListTypes) => {
+const TodoList = ({ todos }: TodoListTypes) => {
   return todos.length ? (
     <ul>
       {todos.map(({ id, title }) => (
-        <TodoItem key={id} id={id} title={title} setTodos={setTodos} />
+        <TodoItem key={id} id={id} title={title} />
       ))}
     </ul>
   ) : (

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useState } from 'react';
+
+interface ITodoStateContext {
+  inputText: string;
+}
+interface ITodoDispatchContext {
+  setInputText: (text: string) => void;
+}
+const TodoStateContext = createContext<ITodoStateContext | null>(null);
+const TodoDispatchContext = createContext<ITodoDispatchContext | null>(null);
+
+function TodoContextProvider({ children }: { children: React.ReactNode }) {
+  const [inputText, setInputText] = useState('');
+
+  return (
+    <TodoStateContext.Provider value={{ inputText }}>
+      <TodoDispatchContext.Provider value={{ setInputText }}>
+        {children}
+      </TodoDispatchContext.Provider>
+    </TodoStateContext.Provider>
+  );
+}
+
+export const useTodoState = () => {
+  const value = useContext(TodoStateContext);
+  if (!value) throw new Error('useTodoState should be used within TodoContextProvider');
+  return value;
+};
+export const useTodoDispatch = () => {
+  const value = useContext(TodoDispatchContext);
+  if (!value) throw new Error('useTodoDispatch should be used within TodoContextProvider');
+  return value;
+};
+
+export default TodoContextProvider;

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -1,20 +1,24 @@
 import { createContext, useContext, useState } from 'react';
+import { TodoTypes } from '../api/todo';
 
 interface ITodoStateContext {
   inputText: string;
+  todoListData: TodoTypes[];
 }
 interface ITodoDispatchContext {
-  setInputText: (text: string) => void;
+  setInputText: React.Dispatch<React.SetStateAction<string>>;
+  setTodoListData: React.Dispatch<React.SetStateAction<TodoTypes[]>>;
 }
 const TodoStateContext = createContext<ITodoStateContext | null>(null);
 const TodoDispatchContext = createContext<ITodoDispatchContext | null>(null);
 
 function TodoContextProvider({ children }: { children: React.ReactNode }) {
   const [inputText, setInputText] = useState('');
+  const [todoListData, setTodoListData] = useState<TodoTypes[]>([]);
 
   return (
-    <TodoStateContext.Provider value={{ inputText }}>
-      <TodoDispatchContext.Provider value={{ setInputText }}>
+    <TodoStateContext.Provider value={{ inputText, todoListData }}>
+      <TodoDispatchContext.Provider value={{ setInputText, setTodoListData }}>
         {children}
       </TodoDispatchContext.Provider>
     </TodoStateContext.Provider>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -9,6 +9,7 @@ import Header from '../components/Header';
 import InputTodo from '../components/InputTodo';
 import SearchedList from '../components/SearchedList';
 import TodoList from '../components/TodoList';
+import { useTodoDispatch, useTodoState } from '../contexts/TodoContext';
 
 const Main = () => {
   // todoListData: 할 일 목록 데이터
@@ -18,7 +19,8 @@ const Main = () => {
   const [searchedResponse, setSearchedResponse] = useState<string[]>([]);
 
   // inputText: 입력된 텍스트
-  const [inputText, setInputText] = useState<string>('');
+  const { inputText } = useTodoState();
+  const { setInputText } = useTodoDispatch();
 
   // isTyping: 입력 중인지 여부
   const [isTyping, setIsTyping] = useState<boolean>(false);
@@ -156,8 +158,6 @@ const Main = () => {
         {isFocused && (
           <SearchedList
             searchedResponse={searchedResponse}
-            inputText={inputText}
-            setInputText={setInputText}
             isNoMoreData={isNoMoreData}
             lastItemRef={lastItemRef}
             isMoreLoading={isMoreLoading}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,4 +1,4 @@
-import { TodoTypes, getTodoList } from '../api/todo';
+import { getTodoList } from '../api/todo';
 
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { createTodo, searchTodo } from '../api/todo';
@@ -12,15 +12,12 @@ import TodoList from '../components/TodoList';
 import { useTodoDispatch, useTodoState } from '../contexts/TodoContext';
 
 const Main = () => {
-  // todoListData: 할 일 목록 데이터
-  const [todoListData, setTodoListData] = useState<TodoTypes[]>([]);
+  // inputText: 입력된 텍스트 & todoListData: 할 일 목록 데이터
+  const { inputText, todoListData } = useTodoState();
+  const { setInputText, setTodoListData } = useTodoDispatch();
 
   // searchedResponse: 검색 결과 데이터
-  const [searchedResponse, setSearchedResponse] = useState<string[]>([]);
-
-  // inputText: 입력된 텍스트
-  const { inputText } = useTodoState();
-  const { setInputText } = useTodoDispatch();
+  const [searchedResponse, setSearchedResponse] = useState<string[]>([]); //
 
   // isTyping: 입력 중인지 여부
   const [isTyping, setIsTyping] = useState<boolean>(false);
@@ -163,7 +160,7 @@ const Main = () => {
             isMoreLoading={isMoreLoading}
           />
         )}
-        <TodoList todos={todoListData} setTodos={setTodoListData} />
+        <TodoList todos={todoListData} />
       </Inner>
     </Container>
   );


### PR DESCRIPTION
## 개요 :mag:
close #13 
> Main 컴포넌트 내 InputTodo, DropDown, ToDoList 등 자식 컴포넌트에서 공통적으로 사용되는 값을 관리하는 context를 새로 생성하여 Main 컴포넌트에서 전역적으로 다루고자 합니다.

## 작업사항 :memo:
1. Main 컴포넌트에서 정의된 값 중에 2 이상 깊이의 자식 컴포넌트에서도 사용되는 값을 context로 공유하였습니다.
2. context에서 접근 가능한 값들에 대해 props를 정리하였습니다.
