### PR TITLE
Refactor: SearchedItem 클릭 시 todo 추가 구현, dropdown rendering 분기

### DIFF
--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -28,7 +28,11 @@ const InputTodo = ({
   isFocused,
 }: InputTodoProps) => {
   return (
-    <StyledForm onSubmit={handleSubmit} isFocused={isFocused} isTyping={inputText.length !== 0}>
+    <StyledForm
+      onSubmit={e => handleSubmit(e, inputText)}
+      isFocused={isFocused}
+      isTyping={inputText.length !== 0}
+    >
       <SearchIcon />
       <StyledInput
         placeholder="Add new todo..."

--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -6,7 +6,7 @@ import { ChangeEvent } from 'react';
 interface InputTodoProps {
   isTyping: boolean;
   isLoading: boolean;
-  handleSubmit: (e: React.FormEvent) => Promise<void>;
+  handleSubmit: (e: React.FormEvent, todoText: string) => Promise<void>;
   inputText: string;
   onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void;
   handleFocus: () => void;
@@ -30,7 +30,11 @@ const InputTodo = ({
   isFocused,
 }: InputTodoProps) => {
   return (
-    <StyledForm onSubmit={handleSubmit} isFocused={isFocused} isTyping={isTyping}>
+    <StyledForm
+      onSubmit={e => handleSubmit(e, inputText)}
+      isFocused={isFocused}
+      isTyping={isTyping}
+    >
       <SearchIcon />
       <StyledInput
         placeholder="Add new todo..."

--- a/src/components/SearchedItem.tsx
+++ b/src/components/SearchedItem.tsx
@@ -1,32 +1,22 @@
-import { useState } from 'react';
 import styled from 'styled-components';
 
 interface SearchedItemProps {
   item: string;
   inputText: string;
-  setInputText: React.Dispatch<React.SetStateAction<string>>;
+  handleSubmit: (e: React.FormEvent, todoText: string) => Promise<void>;
 }
 
-interface ListItemProps {
-  isSelected: boolean;
-}
-
-const SearchedItem = ({ item, inputText, setInputText }: SearchedItemProps) => {
-  // isSelected : 아이템이 선택되었는지 여부.
-  const [isSelected, setIsSelected] = useState<boolean>(false);
-
+const SearchedItem = ({ item, inputText, handleSubmit }: SearchedItemProps) => {
   // splitItem : 검색어를 기준으로 아이템을 분리한 배열을 생성합니다.
   const splitItem = item.split(new RegExp(`(${inputText})`, 'gi'));
 
   // handleItemClick : 아이템을 클릭했을 때 실행되는 처리 함수.
-  const handleItemClick = (event: React.MouseEvent) => {
-    event.preventDefault();
-    setIsSelected(!isSelected);
-    setInputText(item);
+  const handleItemClick = (event: React.MouseEvent<HTMLLIElement>) => {
+    handleSubmit(event, event.currentTarget.innerText);
   };
 
   return (
-    <ListItem onMouseDown={handleItemClick} isSelected={isSelected}>
+    <ListItem onMouseDown={handleItemClick}>
       <ItemContent>
         {splitItem.map((part, index) =>
           part.toLowerCase() === inputText.toLowerCase() ? (
@@ -40,7 +30,7 @@ const SearchedItem = ({ item, inputText, setInputText }: SearchedItemProps) => {
   );
 };
 
-const ListItem = styled.li<ListItemProps>`
+const ListItem = styled.li`
   padding: 5px 3px;
   list-style-type: none;
   cursor: pointer;

--- a/src/components/SearchedItem.tsx
+++ b/src/components/SearchedItem.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { useTodoDispatch, useTodoState } from '../contexts/TodoContext';
 
 interface SearchedItemProps {
   item: string;

--- a/src/components/SearchedList.tsx
+++ b/src/components/SearchedList.tsx
@@ -5,25 +5,25 @@ import { FaSpinner } from 'react-icons/fa';
 interface SearchedListProps {
   searchedResponse: string[];
   inputText: string;
-  setInputText: React.Dispatch<React.SetStateAction<string>>;
   isNoMoreData: boolean;
   lastItemRef: (node: HTMLDivElement | null) => void;
   isMoreLoading: boolean;
+  handleSubmit: (e: React.FormEvent, text: string) => Promise<void>;
 }
 
 const SearchedList = ({
   searchedResponse,
   inputText,
-  setInputText,
   isNoMoreData,
   lastItemRef,
   isMoreLoading,
+  handleSubmit,
 }: SearchedListProps) => {
   return (
     <ListContainer>
       <ul>
         {searchedResponse.map((item, index) => (
-          <SearchedItem key={index} item={item} inputText={inputText} setInputText={setInputText} />
+          <SearchedItem key={index} item={item} inputText={inputText} handleSubmit={handleSubmit} />
         ))}
       </ul>
       {isMoreLoading ? (

--- a/src/components/SearchedList.tsx
+++ b/src/components/SearchedList.tsx
@@ -8,7 +8,7 @@ interface SearchedListProps {
   isMoreData: boolean;
   lastItemRef: (node: HTMLDivElement | null) => void;
   isMoreLoading: boolean;
-  handleSubmit: (e: React.FormEvent, text: string) => Promise<void>;
+  handleSubmit: (e: React.FormEvent, todoText: string) => Promise<void>;
 }
 
 const SearchedList = ({
@@ -31,7 +31,7 @@ const SearchedList = ({
           <Spinner />
         </LoadingContent>
       ) : (
-        isMoreData && <LoadingIndicator ref={lastItemRef}>...</LoadingIndicator>
+        !isMoreData && <LoadingIndicator ref={lastItemRef}>...</LoadingIndicator>
       )}
     </ListContainer>
   );

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -160,6 +160,7 @@ const Main = () => {
             isNoMoreData={isNoMoreData}
             lastItemRef={lastItemRef}
             isMoreLoading={isMoreLoading}
+            handleSubmit={handleSubmit}
           />
         )}
         <TodoList todos={todoListData} setTodos={setTodoListData} />

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -78,7 +78,6 @@ const Main = () => {
       setIsLoading(true);
       const newItem = { title: trimmed };
       const { data } = await createTodo(newItem);
-      setIsTyping(false);
       if (data) {
         setTodoListData(prev => [...prev, data]);
       }
@@ -116,7 +115,7 @@ const Main = () => {
           handleBlur={handleBlur}
           isFocused={isFocused}
         />
-        {isTyping && isFocused && (
+        {debouncedSearchQuery && isFocused && (
           <SearchedList
             searchedResponse={searchedResponse}
             inputText={inputText}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -99,6 +99,7 @@ const Main = () => {
   const handleSubmit = useCallback(
     async (e: React.FormEvent, todoText: string) => {
       e.preventDefault();
+      if (isLoading) return;
       const trimmed = todoText.trim();
       if (!trimmed) return alert('Please write something');
       setIsLoading(true);
@@ -113,7 +114,7 @@ const Main = () => {
       setIsLoading(false);
       setIsFocused(false);
     },
-    [inputText]
+    [isLoading]
   );
 
   useEffect(() => {

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -121,7 +121,7 @@ const Main = () => {
           handleBlur={handleBlur}
           isFocused={isFocused}
         />
-        {isTyping && (
+        {isTyping && isFocused && (
           <SearchedList
             searchedResponse={searchedResponse}
             inputText={inputText}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -105,7 +105,7 @@ const Main = () => {
       setIsLoading(true);
       const newItem = { title: trimmed };
       const { data } = await createTodo(newItem);
-
+      setIsTyping(false);
       if (data) {
         setTodoListData(prev => [...prev, data]);
       }
@@ -154,7 +154,7 @@ const Main = () => {
           handleBlur={handleBlur}
           isFocused={isFocused}
         />
-        {isFocused && (
+        {isTyping && (
           <SearchedList
             searchedResponse={searchedResponse}
             inputText={inputText}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -97,9 +97,9 @@ const Main = () => {
 
   // handleSubmit: 폼 제출 시 처리 함수
   const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
+    async (e: React.FormEvent, todoText: string) => {
       e.preventDefault();
-      const trimmed = inputText.trim();
+      const trimmed = todoText.trim();
       if (!trimmed) return alert('Please write something');
       setIsLoading(true);
       const newItem = { title: trimmed };
@@ -157,7 +157,6 @@ const Main = () => {
           <SearchedList
             searchedResponse={searchedResponse}
             inputText={inputText}
-            setInputText={setInputText}
             isNoMoreData={isNoMoreData}
             lastItemRef={lastItemRef}
             isMoreLoading={isMoreLoading}


### PR DESCRIPTION
## 개요 :mag:

SearchedItem 클릭 시 클릭했던 todo가 추가되고, input 초기화를 구현했습니다.
typing 중 dropdown 이 나타날 수 있게 구현했습니다.

## 작업사항 :memo:

- `handleSubmit` 함수를 재사용하여 구현했습니다.
- SearchedItem component에서 사용하지 않는 state를 삭제했습니다.
- typing state를 이용해 typing 이 시작되면 dropdown 이 나타날 수 있게 구현했습니다.

> **완료**
> - dropdown이 사라지는 시점에 대해 의견을 나누었으면 합니다!
> 현재는 검색결과 item 클릭 후 todo 추가가 되기까지의 시간동안 dropdown이 사라지지 않고, todo가 추가되는 순간 사라집니다. (아래 gif를 참고해주세요 👍 )
> 현재처럼 todo가 추가되기까지 시간동안 dropdown이 사라지지 않을 경우, 그 사이에 다른 검색결과 item을 클릭하게 되면 여러개의 todo가 한꺼번에 추가되는 버그아닌 버그(?) 가 생깁니다.
> 
> <img src=https://github.com/wanted-Team-7/pre-onboarding-10th-4-7/assets/118191378/4e37731b-dd8b-408c-a297-f889905eef70 width=50% height=50% />


close #11 아이템 클릭시 input초기화 & fetch api 
close #9 드랍다운 렌더링 분기

## 테스트 방법
- 검색어 입력 중에 dropdown이 나타나는지 확인해주세요. 
- 검색어 입력 후 검색 결과를 클릭해 정상적으로 todo가 등록되는지 확인해주세요.
