### PR TITLE
Feat: input element loading spinner

### DIFF
--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import SearchIcon from './Icon/SearchIcon';
 import SpinnerIcon from './Icon/SpinnerIcon';
+import { Spinner } from './Icon/TrashIcon';
 import { ChangeEvent } from 'react';
 
 interface InputTodoProps {
@@ -40,7 +41,7 @@ const InputTodo = ({
         onFocus={handleFocus}
         onBlur={handleBlur}
       />
-      {isLoading && <SpinnerIcon />}
+      {isLoading && <Spinner />}
     </StyledForm>
   );
 };

--- a/src/components/SearchedList.tsx
+++ b/src/components/SearchedList.tsx
@@ -42,10 +42,12 @@ const SearchedList = ({
           <Spinner />
         </AlignCenter>
       ) : isNoMoreData ? null : (
-        <Dot />
+        <AlignCenter>
+          <Dot />
+        </AlignCenter>
       )}
 
-      <div ref={lastItemRef}></div>
+      {!isNoMoreData && <div ref={lastItemRef}></div>}
     </ListContainer>
   );
 };

--- a/src/components/SearchedList.tsx
+++ b/src/components/SearchedList.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import SearchedItem from '../components/SearchedItem';
 import { FaSpinner } from 'react-icons/fa';
+import { BiDotsHorizontalRounded } from 'react-icons/bi';
 
 interface SearchedListProps {
   searchedResponse: string[];
@@ -9,6 +10,7 @@ interface SearchedListProps {
   isNoMoreData: boolean;
   lastItemRef: (node: HTMLDivElement | null) => void;
   isMoreLoading: boolean;
+  isLoading: boolean;
 }
 
 const SearchedList = ({
@@ -18,7 +20,14 @@ const SearchedList = ({
   isNoMoreData,
   lastItemRef,
   isMoreLoading,
+  isLoading,
 }: SearchedListProps) => {
+  if (searchedResponse.length === 0)
+    return (
+      <ListContainer>
+        <AlignCenter>검색어 없음</AlignCenter>
+      </ListContainer>
+    );
   return (
     <ListContainer>
       <ul>
@@ -26,16 +35,28 @@ const SearchedList = ({
           <SearchedItem key={index} item={item} inputText={inputText} setInputText={setInputText} />
         ))}
       </ul>
-      {isMoreLoading ? (
-        <LoadingContent>
+
+      {isLoading ? null : isMoreLoading ? (
+        <AlignCenter>
           <FaSpinner className="btn-spinner" />
-        </LoadingContent>
-      ) : (
-        !isNoMoreData && <LoadingIndicator ref={lastItemRef}>...</LoadingIndicator>
+        </AlignCenter>
+      ) : isNoMoreData ? null : (
+        <Dot />
       )}
+
+      <div ref={lastItemRef}></div>
     </ListContainer>
   );
 };
+
+const Dot = styled(BiDotsHorizontalRounded)`
+  color: black;
+`;
+
+const AlignCenter = styled.div`
+  display: flex;
+  justify-content: center;
+`;
 
 const ListContainer = styled.div`
   z-index: 1;
@@ -57,7 +78,7 @@ const LoadingIndicator = styled.div`
   justify-content: center;
 `;
 
-const LoadingContent = styled.div`
+const LoadingContent = styled.li`
   display: flex;
   position: relative;
   height: 30px;

--- a/src/hooks/useSearchData.tsx
+++ b/src/hooks/useSearchData.tsx
@@ -5,12 +5,18 @@ interface UseSearchDataProps {
   setSearchedResponse: React.Dispatch<React.SetStateAction<string[]>>;
   setIsMoreLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setIsNoMoreData: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  checkReSearch: React.MutableRefObject<boolean>;
+  preventRef: React.MutableRefObject<boolean>;
 }
 
 function useSearchData({
   setSearchedResponse,
   setIsMoreLoading,
   setIsNoMoreData,
+  setIsLoading,
+  checkReSearch,
+  preventRef,
 }: UseSearchDataProps) {
   const [currentPage, setCurrentPage] = useState<number>(1);
 
@@ -23,14 +29,20 @@ function useSearchData({
       if (type === 'first') {
         setCurrentPage(1);
         setSearchedResponse([]);
+        setIsLoading(true);
       }
-      if (type === 'scroll') setCurrentPage((prevPage: number) => prevPage + 1);
+      if (type === 'scroll') {
+        setCurrentPage((prevPage: number) => prevPage + 1);
+        setIsMoreLoading(true);
+      }
       const updateCurrentPage = type === 'scroll' ? currentPage + 1 : 1;
-      setIsMoreLoading(true);
       const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
       setSearchedResponse((prevData: string[]) => [...prevData, ...data.result]);
       setIsNoMoreData(data.page * data.limit >= data.total);
+      setIsLoading(false);
       setIsMoreLoading(false);
+      checkReSearch.current = false;
+      preventRef.current = false;
     },
     [currentPage, setIsMoreLoading, setSearchedResponse, setIsNoMoreData]
   );

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -61,8 +61,7 @@ const Main = () => {
     (node: HTMLDivElement | null) => {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver(entries => {
-
-        if (entries[0].isIntersecting) {
+        if (entries[0].isIntersecting && !checkReSearch.current && !preventRef.current) {
           preventRef.current = true;
           handleSearchData('scroll', debouncedSearchQuery);
         }


### PR DESCRIPTION
## 개요 :mag:

input element 로딩 스피너 구현

## 작업사항 :memo:
- isLoading : 기존 isLoading의 의미는 폼 제출 시 로딩 의미 -> handleSearchData('first') 로딩 의미로 변경
- preventRef : 구현 중에 observer callback 함수의 중복 실행 발생하여 변수로 통제했습니다.
- checkReSearch : 재검색할 때는 input 로딩 스피너가 동작하지 않아서, 재검색을 관찰할 Flag가 필요로하여 변수 설정했습니다.

close: #10 

## 테스트 방법(optional)

- 'lorem' 검색을 하고, input element에서 loading spinner의 동작을 확인해 주세요.
- lorem 검색 결과를 끝까지 스크롤하고, 데이터를 다 받아오면 무한 스크롤 종료되는 것을 확인해 주세요.
- 현재 input element에 기입되어 있는검색어 'lorem'을 지우고 다른 키워드를 입력해 주세요.
- 이후 자유롭게 테스트 바랍니다.


