### PR TITLE
style: 사용하지 않는 import type을 삭제

### DIFF
--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { TodoTypes, getTodoList } from '../api/todo';
+import { getTodoList } from '../api/todo';
 import { createTodo } from '../api/todo';
 import useDebounce from '../hooks/useDebounce';
 import useSearchData from '../hooks/useSearchData';


### PR DESCRIPTION
## 개요 :mag:

dev 브랜치에서 코드 읽다가 사용하지 않는 type import가 남아있는 걸 확인했습니다.

## 작업사항 :memo:

사용하지 않는 type import를 삭제했습니다.

- 그냥 단순 작업이라 이슈 따로 안 열었습니다.

## 테스트 방법(optional)

