### PR TITLE
Refactor: useSearchData 훅 의존성 역전

### DIFF
--- a/src/hooks/useSearchData.tsx
+++ b/src/hooks/useSearchData.tsx
@@ -1,18 +1,15 @@
 import { useCallback, useState } from 'react';
 import { searchTodo } from '../api/todo';
 
-interface UseSearchDataProps {
-  setSearchedResponse: React.Dispatch<React.SetStateAction<string[]>>;
-  setIsMoreLoading: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsNoMoreData: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-function useSearchData({
-  setSearchedResponse,
-  setIsMoreLoading,
-  setIsNoMoreData,
-}: UseSearchDataProps) {
+function useSearchData() {
   const [currentPage, setCurrentPage] = useState<number>(1);
+
+  // searchedResponse: 검색 결과 데이터
+  const [searchedResponse, setSearchedResponse] = useState<string[]>([]);
+  // isMoreLoading: 추가 데이터 로딩 중인지 여부
+  const [isMoreLoading, setIsMoreLoading] = useState<boolean>(false);
+  // isNoMoreData: 더 이상 데이터가 없는지 여부
+  const [isNoMoreData, setIsNoMoreData] = useState<boolean>(true);
 
   const handleSearchData = useCallback(
     async (type: string, debouncedSearchQuery: string) => {
@@ -32,10 +29,10 @@ function useSearchData({
       setIsNoMoreData(data.page * data.limit >= data.total);
       setIsMoreLoading(false);
     },
-    [currentPage, setIsMoreLoading, setSearchedResponse, setIsNoMoreData]
+    [currentPage]
   );
 
-  return handleSearchData;
+  return { handleSearchData, searchedResponse, currentPage, isMoreLoading, isNoMoreData };
 }
 
 export default useSearchData;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -16,23 +16,14 @@ const Main = () => {
   const { inputText, todoListData } = useTodoState();
   const { setInputText, setTodoListData } = useTodoDispatch();
 
-  // searchedResponse: 검색 결과 데이터
-  const [searchedResponse, setSearchedResponse] = useState<string[]>([]); //
-
   // isTyping: 입력 중인지 여부
   const [isTyping, setIsTyping] = useState<boolean>(false);
 
   // isLoading: 로딩 중인지 여부
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  // isMoreLoading: 추가 데이터 로딩 중인지 여부
-  const [isMoreLoading, setIsMoreLoading] = useState<boolean>(false);
-
   // isFocused: 입력창이 포커싱되었는지 여부
   const [isFocused, setIsFocused] = useState<boolean>(false);
-
-  // isNoMoreData: 더 이상 데이터가 없는지 여부
-  const [isNoMoreData, setIsNoMoreData] = useState<boolean>(true);
 
   // observer: IntersectionObserver 객체
   const observer = useRef<IntersectionObserver | null>(null);
@@ -40,11 +31,7 @@ const Main = () => {
   // debouncedSearchQuery: 디바운스 적용된 검색어
   const debouncedSearchQuery = useDebounce(inputText, DEBOUNCED_DELAY);
 
-  const handleSearchData = useSearchData({
-    setSearchedResponse,
-    setIsMoreLoading,
-    setIsNoMoreData,
-  });
+  const { handleSearchData, searchedResponse, isMoreLoading, isNoMoreData } = useSearchData();
 
   // lastItemRef: 마지막 항목의 ref 콜백 함수
   const lastItemRef = useCallback(


### PR DESCRIPTION
## 개요 :mag:
#17 

현재의 useSearchData 훅은 외부에서 setState 함수를 전달 받아 실행됩니다. 3개의 setState 함수에 의존하고 있는데, 이 세 함수 모두 이 훅의 역할인 `추천 검색어 fetch`와 관련이 깊습니다.
- setSearchedResponse: 검색 결과값을 처리합니다.
- setIsMoreLoading: 검색 로딩 상태값을 처리합니다.
- isNoMoreData: 추가로 로드할 검색어의 유무 상태값을 처리합니다.



## 작업사항 :memo:

useSearchData 훅은 `추천 검색어 fetch` 로직을 처리하는 훅입니다. 이 훅을 검색 결과, 결과값, 그외 검색과 관련된 모든 정보를 처리한다는 추상에 따라 구현하여 위 세 함수와 state를 훅 내부로 가져왔습니다.


****pr 병합 순서가 올바르지 않아 승인은 안하셔도 됩니다. 코멘트만 부탁드립니다.***
