### PR TITLE
Feat: 인풋창 스피너 구현

### DIFF
--- a/src/components/Icon/DotIcon.tsx
+++ b/src/components/Icon/DotIcon.tsx
@@ -1,0 +1,21 @@
+import { BiDotsHorizontalRounded } from 'react-icons/bi';
+import styled from 'styled-components';
+
+const DotIcon = () => {
+  return (
+    <AlignCenter>
+      <Dot />
+    </AlignCenter>
+  );
+};
+
+const Dot = styled(BiDotsHorizontalRounded)`
+  color: black;
+`;
+
+const AlignCenter = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+export default DotIcon;

--- a/src/components/Icon/SpinnerIcon.tsx
+++ b/src/components/Icon/SpinnerIcon.tsx
@@ -1,14 +1,50 @@
 import { FaSpinner } from 'react-icons/fa';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 // FIXME: SpinnerIcon 개선해야함 (FaSpinner가 사용되는 부분이 있음)
-const SpinnerIcon = () => {
-  return (
-    <Wrapper>
-      <FaSpinner />
-    </Wrapper>
-  );
+const SpinnerIcon = ({ type }: { type: string }) => {
+  switch (type) {
+    case 'scroll':
+      return (
+        <AlignCenter>
+          <Spinner />
+        </AlignCenter>
+      );
+    case 'remove':
+      return <Spinner />;
+    case 'input':
+      return (
+        <Wrapper>
+          <Spinner />
+        </Wrapper>
+      );
+
+    default:
+      return null;
+  }
 };
+
+const AlignCenter = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+  `;
+
+const Spinner = styled(FaSpinner)`
+  color: #000000;
+  font-size: 20px;
+  animation: ${spin} 2s linear infinite;
+  display: flex;
+  align-self: center;
+`;
 
 const Wrapper = styled.div`
   position: absolute;

--- a/src/components/Icon/TrashIcon.tsx
+++ b/src/components/Icon/TrashIcon.tsx
@@ -1,5 +1,6 @@
-import { FaSpinner, FaTrash } from 'react-icons/fa';
-import styled, { keyframes } from 'styled-components';
+import { FaTrash } from 'react-icons/fa';
+import styled from 'styled-components';
+import SpinnerIcon from './SpinnerIcon';
 
 interface TrashIconProps {
   isDeleting: boolean;
@@ -14,28 +15,11 @@ const TrashIcon = ({ isDeleting, handleRemoveTodo }: TrashIconProps) => {
           <Trash />
         </button>
       ) : (
-        <Spinner />
+        <SpinnerIcon type="remove" />
       )}
     </Wrapper>
   );
 };
-
-const spin = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-  `;
-
-export const Spinner = styled(FaSpinner)`
-  color: #000000;
-  font-size: 20px;
-  animation: ${spin} 2s linear infinite;
-  display: flex;
-  align-self: center;
-`;
 
 const Trash = styled(FaTrash)`
   color: orangered;

--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -12,6 +12,7 @@ interface InputTodoProps {
   handleFocus: () => void;
   handleBlur: () => void;
   isFocused: boolean;
+  isSearchLoading: boolean;
 }
 
 interface StyledFormProps {
@@ -28,6 +29,7 @@ const InputTodo = ({
   handleFocus,
   handleBlur,
   isFocused,
+  isSearchLoading,
 }: InputTodoProps) => {
   return (
     <StyledForm onSubmit={handleSubmit} isFocused={isFocused} isTyping={isTyping}>
@@ -40,7 +42,7 @@ const InputTodo = ({
         onFocus={handleFocus}
         onBlur={handleBlur}
       />
-      {isLoading && <SpinnerIcon />}
+      {isSearchLoading && <SpinnerIcon type="input" />}
     </StyledForm>
   );
 };

--- a/src/components/SearchedList.tsx
+++ b/src/components/SearchedList.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import SearchedItem from '../components/SearchedItem';
-import { Spinner } from './Icon/TrashIcon';
+import SpinnerIcon from './Icon/SpinnerIcon';
+import DotIcon from './Icon/DotIcon';
 
 interface SearchedListProps {
   searchedResponse: string[];
@@ -9,6 +10,7 @@ interface SearchedListProps {
   isNoMoreData: boolean;
   lastItemRef: (node: HTMLDivElement | null) => void;
   isMoreLoading: boolean;
+  isSearchLoading: boolean;
 }
 
 const SearchedList = ({
@@ -18,7 +20,16 @@ const SearchedList = ({
   isNoMoreData,
   lastItemRef,
   isMoreLoading,
+  isSearchLoading,
 }: SearchedListProps) => {
+  if (searchedResponse.length === 0)
+    return (
+      <ListContainer>
+        <TextContainer>
+          <span>No Result</span>
+        </TextContainer>
+      </ListContainer>
+    );
   return (
     <ListContainer>
       <ul>
@@ -26,16 +37,28 @@ const SearchedList = ({
           <SearchedItem key={index} item={item} inputText={inputText} setInputText={setInputText} />
         ))}
       </ul>
-      {isMoreLoading ? (
-        <LoadingContent>
-          <Spinner />
-        </LoadingContent>
-      ) : (
-        !isNoMoreData && <LoadingIndicator ref={lastItemRef}>...</LoadingIndicator>
+      {isSearchLoading ? null : isMoreLoading ? (
+        <SpinnerIcon type={'scroll'} />
+      ) : isNoMoreData ? null : (
+        <DotIcon />
       )}
+
+      {!isNoMoreData && <div ref={lastItemRef}></div>}
     </ListContainer>
   );
 };
+
+const TextContainer = styled.div`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+
+  span {
+    font-size: 1.7rem;
+    color: #ececec;
+  }
+`;
 
 const ListContainer = styled.div`
   z-index: 1;
@@ -50,20 +73,6 @@ const ListContainer = styled.div`
   box-shadow: 0 2px 4px 0 rgb(50 50 50 / 10%);
 
   overflow-y: scroll;
-`;
-
-const LoadingIndicator = styled.div`
-  display: flex;
-  justify-content: center;
-`;
-
-const LoadingContent = styled.div`
-  display: flex;
-  position: relative;
-  height: 30px;
-  justify-content: center;
-  align-items: center;
-  cursor: wait;
 `;
 
 export default SearchedList;

--- a/src/components/SearchedList.tsx
+++ b/src/components/SearchedList.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 import SearchedItem from '../components/SearchedItem';
 import SpinnerIcon from './Icon/SpinnerIcon';
-import DotIcon from './Icon/DotIcon';
-
+import { BiDotsHorizontalRounded } from 'react-icons/bi';
 interface SearchedListProps {
   searchedResponse: string[];
   inputText: string;
@@ -40,13 +39,22 @@ const SearchedList = ({
       {isSearchLoading ? null : isMoreLoading ? (
         <SpinnerIcon type={'scroll'} />
       ) : isNoMoreData ? null : (
-        <DotIcon />
+        <AlignCenter ref={lastItemRef}>
+          <Dot />
+        </AlignCenter>
       )}
-
-      {!isNoMoreData && <div ref={lastItemRef}></div>}
     </ListContainer>
   );
 };
+
+const Dot = styled(BiDotsHorizontalRounded)`
+  color: black;
+`;
+
+const AlignCenter = styled.div`
+  display: flex;
+  justify-content: center;
+`;
 
 const TextContainer = styled.div`
   display: flex;

--- a/src/hooks/useSearchData.tsx
+++ b/src/hooks/useSearchData.tsx
@@ -5,12 +5,18 @@ interface UseSearchDataProps {
   setSearchedResponse: React.Dispatch<React.SetStateAction<string[]>>;
   setIsMoreLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setIsNoMoreData: React.Dispatch<React.SetStateAction<boolean>>;
+  setSearchLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  checkReSearch: React.MutableRefObject<boolean>;
+  preventRef: React.MutableRefObject<boolean>;
 }
 
 function useSearchData({
   setSearchedResponse,
   setIsMoreLoading,
   setIsNoMoreData,
+  setSearchLoading,
+  preventRef,
+  checkReSearch,
 }: UseSearchDataProps) {
   const [currentPage, setCurrentPage] = useState<number>(1);
 
@@ -23,14 +29,21 @@ function useSearchData({
       if (type === 'first') {
         setCurrentPage(1);
         setSearchedResponse([]);
+        setSearchLoading(true);
       }
-      if (type === 'scroll') setCurrentPage((prevPage: number) => prevPage + 1);
+      if (type === 'scroll') {
+        setCurrentPage((prevPage: number) => prevPage + 1);
+        setIsMoreLoading(true);
+      }
       const updateCurrentPage = type === 'scroll' ? currentPage + 1 : 1;
-      setIsMoreLoading(true);
+
       const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
       setSearchedResponse((prevData: string[]) => [...prevData, ...data.result]);
       setIsNoMoreData(data.page * data.limit >= data.total);
       setIsMoreLoading(false);
+      setSearchLoading(false);
+      checkReSearch.current = false;
+      preventRef.current = false;
     },
     [currentPage, setIsMoreLoading, setSearchedResponse, setIsNoMoreData]
   );

--- a/src/hooks/useSearchData.tsx
+++ b/src/hooks/useSearchData.tsx
@@ -7,7 +7,6 @@ interface UseSearchDataProps {
   setIsNoMoreData: React.Dispatch<React.SetStateAction<boolean>>;
   setSearchLoading: React.Dispatch<React.SetStateAction<boolean>>;
   checkReSearch: React.MutableRefObject<boolean>;
-  preventRef: React.MutableRefObject<boolean>;
 }
 
 function useSearchData({
@@ -15,7 +14,6 @@ function useSearchData({
   setIsMoreLoading,
   setIsNoMoreData,
   setSearchLoading,
-  preventRef,
   checkReSearch,
 }: UseSearchDataProps) {
   const [currentPage, setCurrentPage] = useState<number>(1);
@@ -43,7 +41,6 @@ function useSearchData({
       setIsMoreLoading(false);
       setSearchLoading(false);
       checkReSearch.current = false;
-      preventRef.current = false;
     },
     [currentPage, setIsMoreLoading, setSearchedResponse, setIsNoMoreData]
   );

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -41,9 +41,6 @@ const Main = () => {
   // debouncedSearchQuery: 디바운스 적용된 검색어
   const debouncedSearchQuery = useDebounce(inputText, DEBOUNCED_DELAY);
 
-  // prevent Observer callback function
-  const preventRef = useRef(false);
-
   // 재 검색 여부 체크
   const checkReSearch = useRef(false);
 
@@ -55,7 +52,6 @@ const Main = () => {
     setIsMoreLoading,
     setIsNoMoreData,
     setSearchLoading,
-    preventRef,
     checkReSearch,
   });
 
@@ -64,8 +60,7 @@ const Main = () => {
     (node: HTMLDivElement | null) => {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting && !checkReSearch.current && !preventRef.current) {
-          preventRef.current = true;
+        if (entries[0].isIntersecting && !checkReSearch.current) {
           handleSearchData('scroll', debouncedSearchQuery);
         }
       });

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -41,10 +41,22 @@ const Main = () => {
   // debouncedSearchQuery: 디바운스 적용된 검색어
   const debouncedSearchQuery = useDebounce(inputText, DEBOUNCED_DELAY);
 
+  // prevent Observer callback function
+  const preventRef = useRef(false);
+
+  // 재 검색 여부 체크
+  const checkReSearch = useRef(false);
+
+  // 검색 로딩 여부
+  const [isSearchLoading, setSearchLoading] = useState<boolean>(false);
+
   const handleSearchData = useSearchData({
     setSearchedResponse,
     setIsMoreLoading,
     setIsNoMoreData,
+    setSearchLoading,
+    preventRef,
+    checkReSearch,
   });
 
   // lastItemRef: 마지막 항목의 ref 콜백 함수
@@ -52,7 +64,8 @@ const Main = () => {
     (node: HTMLDivElement | null) => {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting) {
+        if (entries[0].isIntersecting && !checkReSearch.current && !preventRef.current) {
+          preventRef.current = true;
           handleSearchData('scroll', debouncedSearchQuery);
         }
       });
@@ -63,6 +76,7 @@ const Main = () => {
 
   // onChangeInput: 입력 값 변경 시 처리 함수
   const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length === 0) checkReSearch.current = true;
     setInputText(e.target.value);
   };
 
@@ -120,6 +134,7 @@ const Main = () => {
           handleFocus={handleFocus}
           handleBlur={handleBlur}
           isFocused={isFocused}
+          isSearchLoading={isSearchLoading}
         />
         {isFocused && (
           <SearchedList
@@ -129,6 +144,7 @@ const Main = () => {
             isNoMoreData={isNoMoreData}
             lastItemRef={lastItemRef}
             isMoreLoading={isMoreLoading}
+            isSearchLoading={isSearchLoading}
           />
         )}
         <TodoList todos={todoListData} setTodos={setTodoListData} />


### PR DESCRIPTION
## 개요 :mag:

input element 로딩 스피너 구현

## 작업사항 :memo:
- isSearchLoading : handleSearchData('first') 로딩 체크
- preventRef : 구현 중에 observer callback 함수의 중복 실행 발생하여 변수로 통제했습니다.
- checkReSearch : 재검색할 때는 input 로딩 스피너가 동작하지 않아서, 재검색을 관찰할 Flag가 필요로하여 변수 설정했습니다.
- 여러 곳에서 spinnerIcon이 사용되어 switch문 사용하여 분리했습니다.
- 검색어 없는 경우 'No Result' 컴포넌트 반환합니다

close: #10 

## 테스트 방법(optional)

- 'lorem' 검색을 하고, input element에서 loading spinner의 동작을 확인해 주세요.
- lorem 검색 결과를 끝까지 스크롤하고, 데이터를 다 받아오면 무한 스크롤 종료되는 것을 확인해 주세요.
- 현재 input element에 기입되어 있는검색어 'lorem'을 지우고 다른 키워드를 입력해 주세요.
- 이후 자유롭게 테스트 바랍니다.
