### PR TITLE
Refactor/caching

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint:css
+# npm run lint:css
 npm run lint-front

--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -41,6 +41,5 @@ export const searchTodo = async ({ q, page, limit = 10 }: SearchTodoParams) => {
       limit,
     },
   });
-  console.log('calling api!!');
   return response;
 };

--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -41,6 +41,6 @@ export const searchTodo = async ({ q, page, limit = 10 }: SearchTodoParams) => {
       limit,
     },
   });
-
+  console.log('calling api!!');
   return response;
 };

--- a/src/hooks/useSearchData.tsx
+++ b/src/hooks/useSearchData.tsx
@@ -17,14 +17,11 @@ function useSearchData({
 
   const getSearchData = async (updateCurrentPage: number, debouncedSearchQuery: string) => {
     const cacheData = await getCache(debouncedSearchQuery + updateCurrentPage);
-    console.log(cacheData);
     if (!cacheData) {
-      console.log('caching!!');
       const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
       setCache(debouncedSearchQuery + updateCurrentPage, data, 60 * 1000);
       return data;
     }
-    console.log('cached!!');
     return cacheData;
   };
 

--- a/src/hooks/useSearchData.tsx
+++ b/src/hooks/useSearchData.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { searchTodo } from '../api/todo';
+import { getCache, setCache } from '../utils/cache';
 
 interface UseSearchDataProps {
   setSearchedResponse: React.Dispatch<React.SetStateAction<string[]>>;
@@ -14,6 +15,19 @@ function useSearchData({
 }: UseSearchDataProps) {
   const [currentPage, setCurrentPage] = useState<number>(1);
 
+  const getSearchData = async (updateCurrentPage: number, debouncedSearchQuery: string) => {
+    const cacheData = await getCache(debouncedSearchQuery + updateCurrentPage);
+    console.log(cacheData);
+    if (!cacheData) {
+      console.log('caching!!');
+      const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
+      setCache(debouncedSearchQuery + updateCurrentPage, data, 60 * 1000);
+      return data;
+    }
+    console.log('cached!!');
+    return cacheData;
+  };
+
   const handleSearchData = useCallback(
     async (type: string, debouncedSearchQuery: string) => {
       if (debouncedSearchQuery.trim() === '') {
@@ -27,9 +41,9 @@ function useSearchData({
       if (type === 'scroll') setCurrentPage((prevPage: number) => prevPage + 1);
       const updateCurrentPage = type === 'scroll' ? currentPage + 1 : 1;
       setIsMoreLoading(true);
-      const { data } = await searchTodo({ q: debouncedSearchQuery, page: updateCurrentPage });
-      setSearchedResponse((prevData: string[]) => [...prevData, ...data.result]);
-      setIsNoMoreData(data.page * data.limit >= data.total);
+      const searchData = await getSearchData(updateCurrentPage, debouncedSearchQuery);
+      setSearchedResponse((prevData: string[]) => [...prevData, ...searchData.result]);
+      setIsNoMoreData(searchData.page * searchData.limit >= searchData.total);
       setIsMoreLoading(false);
     },
     [currentPage, setIsMoreLoading, setSearchedResponse, setIsNoMoreData]

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,28 @@
+interface SearchDataType {
+  q: string;
+  result: string[];
+  qty: number;
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export const getCache = async (key: string) => {
+  const cacheStorage = await caches.open('search');
+  const cacheResponse = await cacheStorage.match(key);
+  if (cacheResponse) {
+    const cacheData = await cacheResponse.json();
+    if (cacheData.expire > new Date().getTime()) {
+      return cacheData.value;
+    }
+    cacheStorage.delete(key);
+  }
+};
+
+export const setCache = async (key: string, value: SearchDataType, expireTime: number) => {
+  const cacheStorage = await caches.open('search');
+  const cacheData = new Response(
+    JSON.stringify({ value, expire: new Date().getTime() + expireTime })
+  );
+  await cacheStorage.put(key, cacheData);
+};


### PR DESCRIPTION
## 개요 :mag:
검색 시 이전에 검색한 검색어의 경우 캐싱 된 값으로 처리하면 api 호출을 줄일 수 있다 판단하여 리팩토링을 진행했습니다.

## 작업사항 :memo:
close #26 캐싱 구현
- 캐시를 가져오고 저장하는 유틸 함수를 구현
- `useSearchData` 커스텀 훅에 캐시 적용
- 캐시 유무에 따라 반환되는 데이터를 다르게 하기 위해 `getSearchData`라는 함수로 로직을 따로 분리하여 구현했습니다.
- 무한 스크롤 검색 시에 나오는 검색 결과 값도 처리했습니다.

## 테스트 방법(optional)
테스트를 바로 확인할 수 있도록 `console.log()` 처리를 했습니다.
console.log
cacheData를 가져오는 로그 : **undefined** or **Obejct value**
캐시 유무 로그 : **caching!!** or **cached!!**
api 호출 로그 : **calling api!!**
1. `lorem` 단어를 입력하여 검색해주세요. (undefined와 `cahing!!`, `calling api!!`가 출력되는지 확인해주세요.)
  1-1. 스크롤 검색을 진행합니다. (위와 같은 log가 찍히는지 확인해주세요.)
2. 다른 단어를 입력합니다.
3. 다시 `lorem` 단어를 입력하여 검색해주세요. (cachData와 `cached!!` 가 출력되는지 확인해주세요. 이때 `calling api!!` 는 출력되면 안됩니다.)
  3-1. 스크롤 검색을 진행합니다.  (위와 같은 log가 찍히는지 확인해주세요.)

기본적인 테스트는 위와 같습니다.
다양하게 검색어를 입력하고 스크롤 검색을 진행하시면서 예외가 있는지 테스트 해주세요.

## 주의사항
approve 인원이 충족되어도 merge를 바로 하지 말아주세요. `console.log()`를 전부 제거한 뒤에 따로 할 예정입니다.
